### PR TITLE
Fix power bar & arrow rendering bugs 

### DIFF
--- a/code/Entity/Ball/Ball.Effects.cs
+++ b/code/Entity/Ball/Ball.Effects.cs
@@ -96,7 +96,7 @@ namespace Minigolf
 		private void AdjustArrow()
 		{
 			// Only show the arrow if we're charging a shot, delete otherwise.
-			if ( ShotPower.AlmostEqual( 0 ) )
+			if ( ShotPower < Ball.PowerStrokeThreshold )
 			{
 				if ( PowerArrow != null )
 				{

--- a/code/Entity/Ball/Ball.Input.cs
+++ b/code/Entity/Ball/Ball.Input.cs
@@ -10,6 +10,7 @@ namespace Minigolf
 		/// </summary>
 		public float ShotPower { get; set; } = 0.0f;
 		public float LastShotPower { get; set; } = 0.0f;
+		public const float PowerStrokeThreshold = 0.01f;
 
 		public override void BuildInput( InputBuilder input )
 		{
@@ -23,7 +24,7 @@ namespace Minigolf
 				ShotPower = Math.Clamp( ShotPower - delta, 0, 1 );
 			}
 
-			if ( ShotPower >= 0.01f && !input.Down( InputButton.Attack1 ) )
+			if ( ShotPower >= PowerStrokeThreshold && !input.Down( InputButton.Attack1 ) )
 			{
 				Game.Stroke( Game.Current.BallCamera.Angles.yaw, ShotPower );
 				LastShotPower = ShotPower;

--- a/code/UI/PowerBar.cs
+++ b/code/UI/PowerBar.cs
@@ -13,7 +13,8 @@ namespace Minigolf
 		{
 			if ( Local.Pawn is not Ball ball ) return;
 
-			Bar.Style.Width = Length.Percent( ball.ShotPower * 100 );
+			var percentPower = Length.Percent( ball.ShotPower * 100 );
+			Bar.Style.Width = percentPower?.Value > 1 ? percentPower : 0;
 			Bar.Style.Dirty();
 
 			if ( ball.LastShotPower > 0.0f )


### PR DESCRIPTION
disable rendering while under stroke power threshold also fixes arrow getting "stuck" and remaining without attack1 down.
